### PR TITLE
Lane hit area

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -32,6 +32,11 @@ single_key_hit={
 ]
 }
 
+[layer_names]
+
+2d_physics/layer_1="hit_object"
+2d_physics/layer_2="hit_area"
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,14 @@ FDLoad="*res://addons/fire_droid_core/scenes/fd_load.gd"
 
 enabled=PackedStringArray("res://addons/fire_droid_core/plugin.cfg")
 
+[input]
+
+single_key_hit={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/scenes/hit_object/hit_object.gd
+++ b/scenes/hit_object/hit_object.gd
@@ -53,6 +53,16 @@ func _to_string() -> String:
 	return string
 
 
+## Despawn the object and free it. It is possible to customize despawn behaviour
+## by overriding [method _on_despawn]. Parameter [param is_missed] allows to
+## specify the reason of despawn (by a hit, when [param is_missed] is
+## [code]false[/code], or when the player miss a hit, when [param is_missed]
+## is [code]true[/code]).
+func despawn(is_missed: bool) -> void:
+	await _on_despawn(is_missed)
+	queue_free()
+
+
 ## Sets the spawned flag. This is used by timeline to keep control of wich
 ## HitObjects have already spawned.
 func spawn() -> void:
@@ -81,6 +91,17 @@ func get_ratio() -> float:
 ## ratio [code]1.0[/code] at [member hit_time].
 func get_spawn_time() -> float:
 	return _get_spawn_time()
+
+
+## [b]Overridable method.[/b][br][br]This method is called by [method despawn]
+## and defines the behaviour of the HitObject during despawn, such as changing
+## animation, emitting sound or any other custom action.[br][br]Parameter
+## [param is_missed] allows to customize behaviour when the object is despawned
+## by a hit (when [param is_missed] is [code]false[/code]) or when the player
+## miss a hit (when [param is_missed] is [code]true[/code]).[br][br]Calling
+## [method queue_free] inside this method may cause errors.
+func _on_despawn(is_missed: bool) -> void:
+	pass
 
 
 func _get_spawn_time() -> float:

--- a/scenes/hit_object/lane_hit_object.gd
+++ b/scenes/hit_object/lane_hit_object.gd
@@ -9,3 +9,8 @@ func _init(hit_time: float = 0.0, speed: float = 0.5, lane_index: int = 0) -> vo
 	self.hit_time = hit_time
 	self.speed = speed
 	self.lane_index = lane_index
+
+
+func _on_despawn(is_missed: bool) -> void:
+	if get_parent() is LaneFollower:
+		get_parent().queue_free()

--- a/scenes/level/level.gd
+++ b/scenes/level/level.gd
@@ -33,6 +33,9 @@ func start() -> void:
 		return
 	for minigame: Minigame in minigames.get_children():
 		minigame.level = self
+		minigame.missed_hit.connect(_on_minigame_missed_hit)
+		minigame.success_hit.connect(_on_minigame_success_hit)
+		minigame.failed_hit.connect(_on_minigame_failed_hit)
 	await _update_timeline_hit_objects()
 	_current_minigame_index = 0
 	_change_to_minigame(_current_minigame_index)
@@ -59,6 +62,25 @@ func go_to_next_minigame() -> void:
 	_current_minigame_index += 1
 
 
+func remove_hit_object_from_timeline(hit_object: HitObject, is_missed: bool) -> void:
+	timeline.remove_hit_object(hit_object, is_missed)
+
+
+func _on_minigame_missed_hit() -> void:
+	print("Missed hit!")
+
+
+func _on_minigame_success_hit(ratios: Dictionary) -> void:
+	print("Success hit! Ratios: ", ratios)
+	for hit_object: HitObject in ratios.keys():
+		# <-- Here must calculate score or storage ratio to later calculation
+		remove_hit_object_from_timeline(hit_object, false)
+
+
+func _on_minigame_failed_hit() -> void:
+	print("Failed hit!")
+
+
 func _change_to_minigame(index: int) -> void:
 	for minigame: Minigame in minigames.get_children():
 		minigame.disable()
@@ -70,7 +92,6 @@ func _update_timeline_hit_objects() -> void:
 	var hit_objects: Array[HitObject] = []
 	hit_objects.resize(_hit_objects_infos.size())
 	for info: HitObjectInfo in _hit_objects_infos:
-		#var hit_object: LaneHitObject = LaneHitObject.new()
 		print("Attempting to load \"" + info.scene_path + "\"")
 		var loaded_object = load(info.scene_path)
 		if loaded_object == null:

--- a/scenes/minigame/lane_minigame/lane_hit_area.gd
+++ b/scenes/minigame/lane_minigame/lane_hit_area.gd
@@ -3,10 +3,6 @@ class_name LaneHitArea
 extends Node2D
 
 
-signal hit_missed
-signal hit_succeeded(hit_info: Dictionary)
-
-
 enum AreaShape {
 	CIRCLE,
 	RECTANGLE,
@@ -46,8 +42,7 @@ func _process(delta: float) -> void:
 
 
 func _physics_process(delta: float) -> void:
-	if not Engine.is_editor_hint():
-		_handle_input()
+	pass
 
 
 func _property_can_revert(property: StringName) -> bool:
@@ -100,6 +95,19 @@ func _get_property_list() -> Array[Dictionary]:
 	return property_list
 
 
+## Return a dictionary containing all [HitObject]s inside this area and their
+## ratio (with tolerance applied). Dictionary keys are references to the
+## [HitObject]s, and values are the ratio (between 0.0 and 1.0, according to
+## the distance to perfect_hit_area.[br][br]If the returned dictionary is empty,
+## no object is inside this area.
+func attempt_hit() -> Dictionary:
+	return _get_hit_attempt_info_dictionary()
+
+
+func has_hit_objects_in_area() -> bool:
+	return not _touching_objects.is_empty()
+
+
 func set_shape(new_shape: AreaShape) -> void:
 	shape = new_shape
 	notify_property_list_changed()
@@ -137,19 +145,13 @@ func set_perfect_hit_rectangle_shape_size(value: Vector2) -> void:
 	_update_perfect_hit_area_shape()
 
 
-func _handle_input() -> void:
-	if Input.is_action_just_pressed(input_action):
-		_on_hit_attempt()
-
-
-func _on_hit_attempt() -> void:
+func _get_hit_attempt_info_dictionary() -> Dictionary:
 	if _touching_objects.is_empty():
-		hit_missed.emit()
-		return
+		return {}
 	var hit_info: Dictionary = {} # Key = HitObject | Value = hit_ratio
 	for object: LaneHitObject in _touching_objects:
 		hit_info[object] = _calculate_hit_ratio(object)
-	hit_succeeded.emit(hit_info)
+	return hit_info
 
 
 func _calculate_hit_ratio(hit_object: LaneHitObject) -> float:

--- a/scenes/minigame/lane_minigame/lane_hit_area.gd
+++ b/scenes/minigame/lane_minigame/lane_hit_area.gd
@@ -12,6 +12,8 @@ enum AreaShape {
 	set = set_shape
 @export_range(0, 10, 1, "or_greater") var lane_index: int = 0
 
+var _touching_objects: Array[LaneHitObject] = []
+
 var _circle_shape_radius: float = 10.0:
 	set = set_circle_shape_radius
 var _rectangle_shape_size: Vector2 = Vector2(20.0, 20.0):
@@ -165,3 +167,15 @@ func _update_perfect_hit_area_shape(reset_shape: bool = false) -> void:
 		area_shape.size = _perfect_hit_rectangle_shape_size
 	area_shape.resource_local_to_scene = true
 	perfect_hit_area_collision_shape.set_shape(area_shape)
+
+
+func _on_full_area_area_entered(area: Area2D) -> void:
+	var object = area.get_parent()
+	if object is LaneHitObject and object.lane_index == lane_index:
+		_touching_objects.append(object)
+
+
+func _on_full_area_area_exited(area: Area2D) -> void:
+	var object = area.get_parent()
+	if object is LaneHitObject and object.lane_index == lane_index:
+		_touching_objects.erase(object)

--- a/scenes/minigame/lane_minigame/lane_hit_area.gd
+++ b/scenes/minigame/lane_minigame/lane_hit_area.gd
@@ -27,9 +27,8 @@ var _perfect_hit_rectangle_shape_size: Vector2 = Vector2(20.0, 20.0):
 @onready var full_area_collision_shape: CollisionShape2D = (
 	get_node("FullArea/CollisionShape2D")
 )
-@onready var perfect_hit_area: Area2D = get_node("PerfectHitArea")
-@onready var perfect_hit_area_collision_shape: CollisionShape2D = (
-	get_node("PerfectHitArea/CollisionShape2D")
+@onready var perfect_hit_area_visualizer: MeshInstance2D = (
+	get_node("PerfectHitAreaVisualizer")
 )
 
 
@@ -156,17 +155,18 @@ func _update_full_area_shape(reset_shape: bool = false) -> void:
 func _update_perfect_hit_area_shape(reset_shape: bool = false) -> void:
 	if not is_node_ready():
 		return
-	var area_shape: Shape2D = perfect_hit_area_collision_shape.get_shape()
+	var mesh: Mesh = perfect_hit_area_visualizer.get_mesh()
 	if shape == AreaShape.CIRCLE:
-		if not area_shape is CircleShape2D or reset_shape:
-			area_shape = CircleShape2D.new()
-		area_shape.radius = _perfect_hit_circle_shape_radius
+		if not mesh is SphereMesh or reset_shape:
+			mesh = SphereMesh.new()
+		mesh.radius = _perfect_hit_circle_shape_radius
+		mesh.height = 2 * _perfect_hit_circle_shape_radius
 	elif shape == AreaShape.RECTANGLE:
-		if not area_shape is RectangleShape2D or reset_shape:
-			area_shape = RectangleShape2D.new()
-		area_shape.size = _perfect_hit_rectangle_shape_size
-	area_shape.resource_local_to_scene = true
-	perfect_hit_area_collision_shape.set_shape(area_shape)
+		if not mesh is QuadMesh or reset_shape:
+			mesh = QuadMesh.new()
+		mesh.size = _perfect_hit_rectangle_shape_size
+	mesh.resource_local_to_scene = true
+	perfect_hit_area_visualizer.set_mesh(mesh)
 
 
 func _on_full_area_area_entered(area: Area2D) -> void:

--- a/scenes/minigame/lane_minigame/lane_hit_area.gd
+++ b/scenes/minigame/lane_minigame/lane_hit_area.gd
@@ -1,0 +1,167 @@
+@tool
+class_name LaneHitArea
+extends Node2D
+
+
+enum AreaShape {
+	CIRCLE,
+	RECTANGLE,
+}
+
+@export var shape: AreaShape = AreaShape.RECTANGLE:
+	set = set_shape
+@export_range(0, 10, 1, "or_greater") var lane_index: int = 0
+
+var _circle_shape_radius: float = 10.0:
+	set = set_circle_shape_radius
+var _rectangle_shape_size: Vector2 = Vector2(20.0, 20.0):
+	set = set_rectangle_shape_size
+var _perfect_hit_circle_shape_radius: float = 10.0:
+	set = set_perfect_hit_circle_shape_radius
+var _perfect_hit_rectangle_shape_size: Vector2 = Vector2(20.0, 20.0):
+	set = set_perfect_hit_rectangle_shape_size
+
+@onready var full_area: Area2D = get_node("FullArea")
+@onready var full_area_collision_shape: CollisionShape2D = (
+	get_node("FullArea/CollisionShape2D")
+)
+@onready var perfect_hit_area: Area2D = get_node("PerfectHitArea")
+@onready var perfect_hit_area_collision_shape: CollisionShape2D = (
+	get_node("PerfectHitArea/CollisionShape2D")
+)
+
+
+func _ready() -> void:
+	_update_area_shapes(true)
+
+
+func _process(delta: float) -> void:
+	pass
+
+
+func _physics_process(delta: float) -> void:
+	pass
+
+
+func _property_can_revert(property: StringName) -> bool:
+	if (
+		property == &"_circle_shape_radius"
+		or property == &"_perfect_hit_circle_shape_radius"
+		or property == &"_rectangle_shape_size"
+		or property == &"_perfect_hit_rectangle_shape_size"
+	):
+		return true
+	return false
+
+
+func _property_get_revert(property: StringName) -> Variant:
+	if property == &"_circle_shape_radius":
+		return 20.0
+	elif property == &"_perfect_hit_circle_shape_radius":
+		return 10.0
+	elif property == &"_rectangle_shape_size":
+		return Vector2(20, 20)
+	elif property == &"_perfect_hit_rectangle_shape_size":
+		return Vector2(10, 10)
+	return null
+
+
+func _get_property_list() -> Array[Dictionary]:
+	var property_list: Array[Dictionary] = []
+	if shape == AreaShape.CIRCLE:
+		property_list.append({
+			&"name": "_circle_shape_radius",
+			&"type": TYPE_FLOAT,
+			&"usage": PROPERTY_USAGE_DEFAULT,
+		})
+		property_list.append({
+			&"name": "_perfect_hit_circle_shape_radius",
+			&"type": TYPE_FLOAT,
+			&"usage": PROPERTY_USAGE_DEFAULT,
+		})
+	elif shape == AreaShape.RECTANGLE:
+		property_list.append({
+			&"name": "_rectangle_shape_size",
+			&"type": TYPE_VECTOR2,
+			&"usage": PROPERTY_USAGE_DEFAULT,
+		})
+		property_list.append({
+			&"name": "_perfect_hit_rectangle_shape_size",
+			&"type": TYPE_VECTOR2,
+			&"usage": PROPERTY_USAGE_DEFAULT,
+		})
+	return property_list
+
+
+func set_shape(new_shape: AreaShape) -> void:
+	shape = new_shape
+	notify_property_list_changed()
+	if is_node_ready():
+		_update_area_shapes()
+
+
+func set_circle_shape_radius(value: float) -> void:
+	_circle_shape_radius = value
+	_perfect_hit_circle_shape_radius = clamp(
+		_perfect_hit_circle_shape_radius, 0.0, _circle_shape_radius
+	)
+	_update_area_shapes()
+
+
+func set_perfect_hit_circle_shape_radius(value: float) -> void:
+	_perfect_hit_circle_shape_radius = clamp(
+		value, 0.0, _circle_shape_radius
+	)
+	_update_perfect_hit_area_shape()
+
+
+func set_rectangle_shape_size(value: Vector2) -> void:
+	_rectangle_shape_size = value
+	_perfect_hit_rectangle_shape_size = _perfect_hit_rectangle_shape_size.clamp(
+		Vector2.ZERO, _rectangle_shape_size
+	)
+	_update_area_shapes()
+
+
+func set_perfect_hit_rectangle_shape_size(value: Vector2) -> void:
+	_perfect_hit_rectangle_shape_size = (
+		value.clamp(Vector2.ZERO, _rectangle_shape_size)
+	)
+	_update_perfect_hit_area_shape()
+
+
+func _update_area_shapes(reset_shape: bool = false) -> void:
+	_update_full_area_shape(reset_shape)
+	_update_perfect_hit_area_shape(reset_shape)
+
+
+func _update_full_area_shape(reset_shape: bool = false) -> void:
+	if not is_node_ready():
+		return
+	var area_shape: Shape2D = full_area_collision_shape.get_shape()
+	if shape == AreaShape.CIRCLE:
+		if not area_shape is CircleShape2D or reset_shape:
+			area_shape = CircleShape2D.new()
+		area_shape.radius = _circle_shape_radius
+	elif shape == AreaShape.RECTANGLE:
+		if not area_shape is RectangleShape2D or reset_shape:
+			area_shape = RectangleShape2D.new()
+		area_shape.size = _rectangle_shape_size
+	area_shape.resource_local_to_scene = true
+	full_area_collision_shape.set_shape(area_shape)
+
+
+func _update_perfect_hit_area_shape(reset_shape: bool = false) -> void:
+	if not is_node_ready():
+		return
+	var area_shape: Shape2D = perfect_hit_area_collision_shape.get_shape()
+	if shape == AreaShape.CIRCLE:
+		if not area_shape is CircleShape2D or reset_shape:
+			area_shape = CircleShape2D.new()
+		area_shape.radius = _perfect_hit_circle_shape_radius
+	elif shape == AreaShape.RECTANGLE:
+		if not area_shape is RectangleShape2D or reset_shape:
+			area_shape = RectangleShape2D.new()
+		area_shape.size = _perfect_hit_rectangle_shape_size
+	area_shape.resource_local_to_scene = true
+	perfect_hit_area_collision_shape.set_shape(area_shape)

--- a/scenes/minigame/lane_minigame/lane_hit_area.tscn
+++ b/scenes/minigame/lane_minigame/lane_hit_area.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=4 format=3 uid="uid://c4xd7y06s28dg"]
+
+[ext_resource type="Script" path="res://scenes/minigame/lane_minigame/lane_hit_area.gd" id="1_xk0re"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_pnf4r"]
+resource_local_to_scene = true
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_cvydo"]
+resource_local_to_scene = true
+size = Vector2(10, 10)
+
+[node name="LaneHitArea" type="Node2D"]
+script = ExtResource("1_xk0re")
+_rectangle_shape_size = Vector2(20, 20)
+_perfect_hit_rectangle_shape_size = Vector2(10, 10)
+
+[node name="FullArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="FullArea"]
+shape = SubResource("RectangleShape2D_pnf4r")
+
+[node name="PerfectHitArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PerfectHitArea"]
+shape = SubResource("RectangleShape2D_cvydo")
+debug_color = Color(0.782052, 0.435604, 1.73271e-06, 0.42)

--- a/scenes/minigame/lane_minigame/lane_hit_area.tscn
+++ b/scenes/minigame/lane_minigame/lane_hit_area.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://scenes/minigame/lane_minigame/lane_hit_area.gd" id="1_xk0re"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_ww13l"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_md84s"]
 resource_local_to_scene = true
 
-[sub_resource type="QuadMesh" id="QuadMesh_63brq"]
+[sub_resource type="QuadMesh" id="QuadMesh_1t6ht"]
 resource_local_to_scene = true
 size = Vector2(10, 10)
 
@@ -18,7 +18,6 @@ gradient = SubResource("Gradient_xxgxu")
 
 [node name="LaneHitArea" type="Node2D"]
 script = ExtResource("1_xk0re")
-input_action = null
 _rectangle_shape_size = Vector2(20, 20)
 _perfect_hit_rectangle_shape_size = Vector2(10, 10)
 
@@ -26,13 +25,11 @@ _perfect_hit_rectangle_shape_size = Vector2(10, 10)
 collision_layer = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="FullArea"]
-shape = SubResource("RectangleShape2D_ww13l")
+shape = SubResource("RectangleShape2D_md84s")
 
 [node name="PerfectHitAreaVisualizer" type="MeshInstance2D" parent="."]
-mesh = SubResource("QuadMesh_63brq")
+mesh = SubResource("QuadMesh_1t6ht")
 texture = SubResource("GradientTexture1D_fc32a")
-
-[node name="Area2D" type="Area2D" parent="."]
 
 [connection signal="area_entered" from="FullArea" to="." method="_on_full_area_area_entered"]
 [connection signal="area_exited" from="FullArea" to="." method="_on_full_area_area_exited"]

--- a/scenes/minigame/lane_minigame/lane_hit_area.tscn
+++ b/scenes/minigame/lane_minigame/lane_hit_area.tscn
@@ -1,26 +1,38 @@
-[gd_scene load_steps=4 format=3 uid="uid://c4xd7y06s28dg"]
+[gd_scene load_steps=6 format=3 uid="uid://c4xd7y06s28dg"]
 
 [ext_resource type="Script" path="res://scenes/minigame/lane_minigame/lane_hit_area.gd" id="1_xk0re"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_pnf4r"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ww13l"]
 resource_local_to_scene = true
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_cvydo"]
+[sub_resource type="QuadMesh" id="QuadMesh_63brq"]
 resource_local_to_scene = true
 size = Vector2(10, 10)
 
+[sub_resource type="Gradient" id="Gradient_xxgxu"]
+offsets = PackedFloat32Array(0)
+colors = PackedColorArray(0.780392, 0.435294, 0, 0.419608)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_fc32a"]
+gradient = SubResource("Gradient_xxgxu")
+
 [node name="LaneHitArea" type="Node2D"]
 script = ExtResource("1_xk0re")
+input_action = null
 _rectangle_shape_size = Vector2(20, 20)
 _perfect_hit_rectangle_shape_size = Vector2(10, 10)
 
 [node name="FullArea" type="Area2D" parent="."]
+collision_layer = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="FullArea"]
-shape = SubResource("RectangleShape2D_pnf4r")
+shape = SubResource("RectangleShape2D_ww13l")
 
-[node name="PerfectHitArea" type="Area2D" parent="."]
+[node name="PerfectHitAreaVisualizer" type="MeshInstance2D" parent="."]
+mesh = SubResource("QuadMesh_63brq")
+texture = SubResource("GradientTexture1D_fc32a")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="PerfectHitArea"]
-shape = SubResource("RectangleShape2D_cvydo")
-debug_color = Color(0.782052, 0.435604, 1.73271e-06, 0.42)
+[node name="Area2D" type="Area2D" parent="."]
+
+[connection signal="area_entered" from="FullArea" to="." method="_on_full_area_area_entered"]
+[connection signal="area_exited" from="FullArea" to="." method="_on_full_area_area_exited"]

--- a/scenes/minigame/lane_minigame/lane_minigame.gd
+++ b/scenes/minigame/lane_minigame/lane_minigame.gd
@@ -3,21 +3,23 @@ extends Minigame
 
 
 var level: Level = null
+var _hit_areas_groups: Dictionary = {} # Grouped by input_action: {&"action": [area1, area2, ...]}
+var _total_time: float = 0.0
 
 @onready var lanes: Node2D = get_node("Lanes")
 @onready var hit_areas: Node2D = get_node("HitAreas")
 
 
 func _ready() -> void:
-	pass
+	_setup_hit_areas()
 
 
 func _process(_delta: float) -> void:
-	pass
+	_total_time += _delta
 
 
 func _physics_process(_delta: float) -> void:
-	pass
+	_handle_input()
 
 
 func _on_spawn_hit_object(hit_object: HitObject, args: Dictionary = {}) -> void:
@@ -37,3 +39,24 @@ func _on_spawn_hit_object(hit_object: HitObject, args: Dictionary = {}) -> void:
 	lane.add_child(lane_follower)
 	hit_object.target_ratio = lane.hit_ratio
 	lane_follower.add_child(hit_object)
+
+
+func _setup_hit_areas() -> void:
+	for hit_area: LaneHitArea in hit_areas.get_children():
+		if not _hit_areas_groups.has(hit_area.input_action):
+			_hit_areas_groups[hit_area.input_action] = []
+		_hit_areas_groups[hit_area.input_action].append(hit_area)
+
+
+func _handle_input() -> void:
+	for input_action: StringName in _hit_areas_groups.keys():
+		if not Input.is_action_just_pressed(input_action):
+			continue
+		var detected_hits: Dictionary = {}
+		for hit_area: LaneHitArea in _hit_areas_groups[input_action]:
+			detected_hits.merge(hit_area.attempt_hit())
+		if detected_hits.is_empty():
+			missed_hit.emit()
+			return
+		success_hit.emit(detected_hits)
+	#

--- a/scenes/minigame/lane_minigame/lane_minigame.gd
+++ b/scenes/minigame/lane_minigame/lane_minigame.gd
@@ -5,6 +5,7 @@ extends Minigame
 var level: Level = null
 
 @onready var lanes: Node2D = get_node("Lanes")
+@onready var hit_areas: Node2D = get_node("HitAreas")
 
 
 func _ready() -> void:

--- a/scenes/minigame/lane_minigame/lane_minigame.tscn
+++ b/scenes/minigame/lane_minigame/lane_minigame.tscn
@@ -6,3 +6,5 @@
 script = ExtResource("1_nam73")
 
 [node name="Lanes" type="Node2D" parent="."]
+
+[node name="HitAreas" type="Node2D" parent="."]

--- a/scenes/minigame/minigame.gd
+++ b/scenes/minigame/minigame.gd
@@ -2,6 +2,11 @@ class_name Minigame
 extends Node2D
 
 
+signal failed_hit
+signal success_hit(ratios: Dictionary)
+signal missed_hit(hit_object: HitObject)
+
+
 var _is_enabled: bool = false
 
 

--- a/scenes/sync_core/timeline.gd
+++ b/scenes/sync_core/timeline.gd
@@ -25,7 +25,6 @@ func _physics_process(delta: float) -> void:
 
 func start() -> void:
 	set_process(true)
-	print("Starting timeline")
 
 
 func get_current_time() -> float:
@@ -48,6 +47,14 @@ func get_hit_objects() -> Array[HitObject]:
 
 func add_hit_object(hit_object: HitObject) -> void:
 	_hit_objects.append(hit_object)
+
+
+func remove_hit_object(hit_object: HitObject, is_missed: bool) -> void:
+	var found_index: int = _hit_objects.find(hit_object)
+	if found_index == -1:
+		return
+	var found_object: HitObject = _hit_objects.pop_at(found_index)
+	found_object.despawn(is_missed)
 
 
 func get_hit_object(index: int) -> HitObject:
@@ -81,9 +88,9 @@ func _handle_spawns() -> void:
 
 func _insert_hit_object_sorted(hit_object: HitObject) -> void:
 	hit_object.timeline = self
-	hit_object.reached_hit_time.connect(
-		func(object: HitObject): print(">> Hit: ", hit_object)
-	)
+	#hit_object.reached_hit_time.connect(
+		#func(object: HitObject): print(">> Hit: ", hit_object)
+	#)
 	var index = 0
 	var spawn_time: float = hit_object.get_spawn_time()
 	var aux_spawn_time: float = _hit_objects[index].get_spawn_time()

--- a/test/test_lane_hit_object.tscn
+++ b/test/test_lane_hit_object.tscn
@@ -15,7 +15,7 @@ fill_from = Vector2(0.5, 0.5)
 fill_to = Vector2(0, 0)
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_lfcb5"]
-radius = 32.0
+radius = 48.0
 
 [node name="TestLaneHitObject" type="Node2D"]
 script = ExtResource("1_4k6i5")

--- a/test/test_lane_hit_object.tscn
+++ b/test/test_lane_hit_object.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://cxewl7q4l3lxr"]
+[gd_scene load_steps=5 format=3 uid="uid://cxewl7q4l3lxr"]
 
 [ext_resource type="Script" path="res://scenes/hit_object/lane_hit_object.gd" id="1_4k6i5"]
 
@@ -14,8 +14,17 @@ fill = 1
 fill_from = Vector2(0.5, 0.5)
 fill_to = Vector2(0, 0)
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_lfcb5"]
+radius = 32.0
+
 [node name="TestLaneHitObject" type="Node2D"]
 script = ExtResource("1_4k6i5")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = SubResource("GradientTexture2D_ybabj")
+
+[node name="Area2D" type="Area2D" parent="."]
+collision_mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource("CircleShape2D_lfcb5")

--- a/test/test_lane_minigame.tscn
+++ b/test/test_lane_minigame.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://ceospd5qxmosv"]
+[gd_scene load_steps=6 format=3 uid="uid://ceospd5qxmosv"]
 
 [ext_resource type="PackedScene" uid="uid://derhm4barxqjd" path="res://scenes/minigame/lane_minigame/lane_minigame.tscn" id="1_3t6qa"]
 [ext_resource type="Script" path="res://scenes/minigame/lane_minigame/hit_lane.gd" id="2_43pd5"]
-[ext_resource type="PackedScene" uid="uid://cxewl7q4l3lxr" path="res://test/test_lane_hit_object.tscn" id="3_lt2md"]
 [ext_resource type="PackedScene" uid="uid://c4xd7y06s28dg" path="res://scenes/minigame/lane_minigame/lane_hit_area.tscn" id="3_nh2tm"]
 
 [sub_resource type="Curve2D" id="Curve2D_2oge4"]
@@ -26,65 +25,6 @@ points = PackedVector2Array(960, 0, 960, 648)
 curve = SubResource("Curve2D_2oge4")
 script = ExtResource("2_43pd5")
 
-[node name="PathFollow2D" type="PathFollow2D" parent="Lanes/HitLane" index="0"]
-visible = false
-position = Vector2(898.972, 101.201)
-rotation = -0.0579059
-progress = 860.679
-rotates = false
-loop = false
-
-[node name="Fora" parent="Lanes/HitLane/PathFollow2D" index="0" instance=ExtResource("3_lt2md")]
-
-[node name="PathFollow2D2" type="PathFollow2D" parent="Lanes/HitLane" index="1"]
-visible = false
-position = Vector2(933.96, 99.5332)
-rotation = -0.0579059
-progress = 895.722
-rotates = false
-loop = false
-
-[node name="Pouco" parent="Lanes/HitLane/PathFollow2D2" index="0" instance=ExtResource("3_lt2md")]
-
-[node name="PathFollow2D3" type="PathFollow2D" parent="Lanes/HitLane" index="2"]
-visible = false
-position = Vector2(940.679, 99.5936)
-rotation = -0.0579059
-progress = 902.441
-rotates = false
-loop = false
-
-[node name="Medio" parent="Lanes/HitLane/PathFollow2D3" index="0" instance=ExtResource("3_lt2md")]
-
-[node name="PathFollow2D4" type="PathFollow2D" parent="Lanes/HitLane" index="3"]
-position = Vector2(949.241, 99.8275)
-rotation = -0.0579059
-progress = 911.005
-rotates = false
-loop = false
-
-[node name="Perto" parent="Lanes/HitLane/PathFollow2D4" index="0" instance=ExtResource("3_lt2md")]
-
-[node name="PathFollow2D5" type="PathFollow2D" parent="Lanes/HitLane" index="4"]
-visible = false
-position = Vector2(951.871, 99.9332)
-rotation = -0.0579059
-progress = 913.639
-rotates = false
-loop = false
-
-[node name="PoucoDentro" parent="Lanes/HitLane/PathFollow2D5" index="0" instance=ExtResource("3_lt2md")]
-
-[node name="PathFollow2D6" type="PathFollow2D" parent="Lanes/HitLane" index="5"]
-visible = false
-position = Vector2(959.766, 100.342)
-rotation = -0.0579059
-progress = 921.544
-rotates = false
-loop = false
-
-[node name="MuitoDentro" parent="Lanes/HitLane/PathFollow2D6" index="0" instance=ExtResource("3_lt2md")]
-
 [node name="HitLane2" type="Path2D" parent="Lanes" index="1"]
 curve = SubResource("Curve2D_lr5sr")
 script = ExtResource("2_43pd5")
@@ -92,6 +32,13 @@ hit_ratio = 0.697
 
 [node name="LaneHitArea" parent="HitAreas" index="0" instance=ExtResource("3_nh2tm")]
 position = Vector2(960, 100)
+input_action = &"single_key_hit"
+_rectangle_shape_size = Vector2(55, 50)
+_perfect_hit_rectangle_shape_size = Vector2(20, 40)
+
+[node name="LaneHitArea2" parent="HitAreas" index="1" instance=ExtResource("3_nh2tm")]
+position = Vector2(960, 308)
+lane_index = 1
 input_action = &"single_key_hit"
 _rectangle_shape_size = Vector2(55, 50)
 _perfect_hit_rectangle_shape_size = Vector2(20, 40)

--- a/test/test_lane_minigame.tscn
+++ b/test/test_lane_minigame.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://ceospd5qxmosv"]
+[gd_scene load_steps=7 format=3 uid="uid://ceospd5qxmosv"]
 
 [ext_resource type="PackedScene" uid="uid://derhm4barxqjd" path="res://scenes/minigame/lane_minigame/lane_minigame.tscn" id="1_3t6qa"]
 [ext_resource type="Script" path="res://scenes/minigame/lane_minigame/hit_lane.gd" id="2_43pd5"]
+[ext_resource type="PackedScene" uid="uid://cxewl7q4l3lxr" path="res://test/test_lane_hit_object.tscn" id="3_lt2md"]
+[ext_resource type="PackedScene" uid="uid://c4xd7y06s28dg" path="res://scenes/minigame/lane_minigame/lane_hit_area.tscn" id="3_nh2tm"]
 
 [sub_resource type="Curve2D" id="Curve2D_2oge4"]
 _data = {
@@ -24,7 +26,72 @@ points = PackedVector2Array(960, 0, 960, 648)
 curve = SubResource("Curve2D_2oge4")
 script = ExtResource("2_43pd5")
 
+[node name="PathFollow2D" type="PathFollow2D" parent="Lanes/HitLane" index="0"]
+visible = false
+position = Vector2(898.972, 101.201)
+rotation = -0.0579059
+progress = 860.679
+rotates = false
+loop = false
+
+[node name="Fora" parent="Lanes/HitLane/PathFollow2D" index="0" instance=ExtResource("3_lt2md")]
+
+[node name="PathFollow2D2" type="PathFollow2D" parent="Lanes/HitLane" index="1"]
+visible = false
+position = Vector2(933.96, 99.5332)
+rotation = -0.0579059
+progress = 895.722
+rotates = false
+loop = false
+
+[node name="Pouco" parent="Lanes/HitLane/PathFollow2D2" index="0" instance=ExtResource("3_lt2md")]
+
+[node name="PathFollow2D3" type="PathFollow2D" parent="Lanes/HitLane" index="2"]
+visible = false
+position = Vector2(940.679, 99.5936)
+rotation = -0.0579059
+progress = 902.441
+rotates = false
+loop = false
+
+[node name="Medio" parent="Lanes/HitLane/PathFollow2D3" index="0" instance=ExtResource("3_lt2md")]
+
+[node name="PathFollow2D4" type="PathFollow2D" parent="Lanes/HitLane" index="3"]
+position = Vector2(949.241, 99.8275)
+rotation = -0.0579059
+progress = 911.005
+rotates = false
+loop = false
+
+[node name="Perto" parent="Lanes/HitLane/PathFollow2D4" index="0" instance=ExtResource("3_lt2md")]
+
+[node name="PathFollow2D5" type="PathFollow2D" parent="Lanes/HitLane" index="4"]
+visible = false
+position = Vector2(951.871, 99.9332)
+rotation = -0.0579059
+progress = 913.639
+rotates = false
+loop = false
+
+[node name="PoucoDentro" parent="Lanes/HitLane/PathFollow2D5" index="0" instance=ExtResource("3_lt2md")]
+
+[node name="PathFollow2D6" type="PathFollow2D" parent="Lanes/HitLane" index="5"]
+visible = false
+position = Vector2(959.766, 100.342)
+rotation = -0.0579059
+progress = 921.544
+rotates = false
+loop = false
+
+[node name="MuitoDentro" parent="Lanes/HitLane/PathFollow2D6" index="0" instance=ExtResource("3_lt2md")]
+
 [node name="HitLane2" type="Path2D" parent="Lanes" index="1"]
 curve = SubResource("Curve2D_lr5sr")
 script = ExtResource("2_43pd5")
 hit_ratio = 0.697
+
+[node name="LaneHitArea" parent="HitAreas" index="0" instance=ExtResource("3_nh2tm")]
+position = Vector2(960, 100)
+input_action = &"single_key_hit"
+_rectangle_shape_size = Vector2(55, 50)
+_perfect_hit_rectangle_shape_size = Vector2(20, 40)


### PR DESCRIPTION
# Relevant changes:
- Created LaneHitArea
- Renamed physics layers
- Implemented logic for syncing HitObjects from Minigame timeline
- Implemented handler for Input action press on LaneMinigame
  - Each lane can have it's own input_action
  - Lanes with same input_actions are handled together, so missed_hit signal is emitted only when none of lanes with a common input_action is pressed