### PR TITLE
Audacity Label Parser

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,11 @@ FDLoad="*res://addons/fire_droid_core/scenes/fd_load.gd"
 
 enabled=PackedStringArray("res://addons/fire_droid_core/plugin.cfg")
 
+[fd_core]
+
+intro_paths=[]
+initial_scene="res://test/test_level.tscn"
+
 [input]
 
 single_key_hit={

--- a/scenes/sync_core/audacity_label_parser.gd
+++ b/scenes/sync_core/audacity_label_parser.gd
@@ -1,0 +1,81 @@
+@tool
+class_name AudacityLabelParser
+extends Node
+
+
+const _MinigameMode: Dictionary = {
+	"SK": HitObjectInfo.Type.LANE,
+	"MK": HitObjectInfo.Type.LANE,
+	"CLK": HitObjectInfo.Type.CLICK,
+}
+
+
+@export_multiline var label_file_content: String = ""
+@export_file("*.tscn") var single_key_hit_object_scene_path: String = ""
+@export_file("*.tscn") var multi_key_hit_object_scene_path: String = ""
+@export_file("*.tscn") var click_hit_object_scene_path: String = ""
+@export var generate_result: bool = false:
+	set(value):
+		_process_content()
+@export var result: Array[HitObjectInfo] = []:
+	set = _set_result
+
+var _is_processing_file: bool = false
+
+
+func _ready() -> void:
+	if not Engine.is_editor_hint():
+		queue_free()
+
+
+func _process_content() -> void:
+	var line_index: int = 0
+	var null_infos_count: int = 0
+	var lines: PackedStringArray = label_file_content.split("\n")
+	var result: Array[HitObjectInfo] = []
+	result.resize(lines.size())
+	for line: String in lines:
+		var info: HitObjectInfo = _process_line(line, line_index)
+		if info == null:
+			FDCore.warning(
+				"AudacityLabelParser: Error while processing content from line "
+				+ str(line_index)
+			)
+			null_infos_count += 1
+			continue
+		result[line_index - null_infos_count] = info
+		line_index += 1
+	result = result.slice(0, result.size() - null_infos_count)
+	_is_processing_file = true
+	self.result = result
+	_is_processing_file = false
+
+
+
+func _process_line(line: String, index: int) -> HitObjectInfo:
+	var splitted: PackedStringArray = line.replace("\"", "").split(" ")
+	if not splitted.size() == 4:
+		FDCore.warning(
+			"AudacityLabelParser: Line Process: Line has more than 4 parameters!"
+		)
+		return null
+	var info: HitObjectInfo = HitObjectInfo.new()
+	info.hit_time = float(splitted[1])
+	info.type = _MinigameMode.get(splitted[3],  HitObjectInfo.Type.UNDEFINED)
+	info.lane_index = int(splitted[0].split("-", true, 2)[1])
+	match splitted[3]:
+		"SK": info.scene_path = single_key_hit_object_scene_path
+		"MK": info.scene_path = multi_key_hit_object_scene_path
+		"CLK": info.scene_path = click_hit_object_scene_path
+	return info
+
+
+func _set_result(value: Array[HitObjectInfo]) -> void:
+	if not _is_processing_file:
+		print_rich(
+			"[color=yellow]"
+			+ "AudacityLabelParser: Result is a read-only property!"
+			+ "[/color]"
+		)
+		return
+	result = value

--- a/test/test_level.tscn
+++ b/test/test_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=58 format=3 uid="uid://d2ca8mtbol5ag"]
+[gd_scene load_steps=110 format=3 uid="uid://d2ca8mtbol5ag"]
 
 [ext_resource type="PackedScene" uid="uid://c7kjmkwnf5um3" path="res://scenes/level/level.tscn" id="1_2m27j"]
 [ext_resource type="Script" path="res://scenes/level/resources/hit_object_info.gd" id="2_1i7lb"]
@@ -6,260 +6,144 @@
 [ext_resource type="AudioStream" uid="uid://n0ijv3b4gvbs" path="res://test/holiday_weasel.ogg" id="3_i8wa8"]
 [ext_resource type="Script" path="res://scenes/level/resources/minigame_transition_info.gd" id="3_ppyrm"]
 [ext_resource type="PackedScene" uid="uid://cmw70pxlc43iq" path="res://test/test_multi_key_minigame.tscn" id="6_1lc5a"]
+[ext_resource type="Script" path="res://scenes/sync_core/audacity_label_parser.gd" id="7_iochn"]
 
-[sub_resource type="Resource" id="Resource_dubkq"]
+[sub_resource type="Resource" id="Resource_mmspf"]
 script = ExtResource("2_1i7lb")
-hit_time = 4.44
+hit_time = 4.44111
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_kh1iu"]
+[sub_resource type="Resource" id="Resource_2j61d"]
 script = ExtResource("2_1i7lb")
-hit_time = 5.28
+hit_time = 5.27848
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_iaolx"]
+[sub_resource type="Resource" id="Resource_s14wv"]
 script = ExtResource("2_1i7lb")
-hit_time = 6.11
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_3noxh"]
-script = ExtResource("2_1i7lb")
-hit_time = 6.94
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_mst38"]
-script = ExtResource("2_1i7lb")
-hit_time = 7.76
+hit_time = 7.75868
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_i6l6g"]
+[sub_resource type="Resource" id="Resource_vgobn"]
 script = ExtResource("2_1i7lb")
-hit_time = 8.58
+hit_time = 8.57816
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_lp1k5"]
+[sub_resource type="Resource" id="Resource_jvhl7"]
 script = ExtResource("2_1i7lb")
-hit_time = 10.62
+hit_time = 10.6202
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_eq8ha"]
+[sub_resource type="Resource" id="Resource_ikqeb"]
 script = ExtResource("2_1i7lb")
-hit_time = 11.43
+hit_time = 11.4287
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_tauwe"]
+[sub_resource type="Resource" id="Resource_16sny"]
 script = ExtResource("2_1i7lb")
-hit_time = 12.25
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_llk2f"]
-script = ExtResource("2_1i7lb")
-hit_time = 12.65
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_ia41a"]
-script = ExtResource("2_1i7lb")
-hit_time = 13.04
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_a3eif"]
-script = ExtResource("2_1i7lb")
-hit_time = 13.9
+hit_time = 13.908
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_o8qdm"]
+[sub_resource type="Resource" id="Resource_woy21"]
 script = ExtResource("2_1i7lb")
-hit_time = 14.32
+hit_time = 14.3253
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_0p553"]
+[sub_resource type="Resource" id="Resource_6drhp"]
 script = ExtResource("2_1i7lb")
-hit_time = 14.74
+hit_time = 14.7421
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_r7pgp"]
+[sub_resource type="Resource" id="Resource_uk5wm"]
 script = ExtResource("2_1i7lb")
-hit_time = 15.57
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_x77y4"]
-script = ExtResource("2_1i7lb")
-hit_time = 15.97
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_ixasb"]
-script = ExtResource("2_1i7lb")
-hit_time = 16.37
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_k64kr"]
-script = ExtResource("2_1i7lb")
-hit_time = 17.19
+hit_time = 17.195
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_81q3p"]
+[sub_resource type="Resource" id="Resource_4krew"]
 script = ExtResource("2_1i7lb")
-hit_time = 18.0
+hit_time = 18.0043
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_or4bv"]
+[sub_resource type="Resource" id="Resource_agtg6"]
 script = ExtResource("2_1i7lb")
-hit_time = 18.87
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_7xod2"]
-script = ExtResource("2_1i7lb")
-hit_time = 19.26
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_3w7ms"]
-script = ExtResource("2_1i7lb")
-hit_time = 19.66
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_pwlkc"]
-script = ExtResource("2_1i7lb")
-hit_time = 20.5
+hit_time = 20.5063
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_vx4cd"]
+[sub_resource type="Resource" id="Resource_0if1l"]
 script = ExtResource("2_1i7lb")
-hit_time = 20.9
+hit_time = 20.8995
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_cdvkg"]
+[sub_resource type="Resource" id="Resource_ps03s"]
 script = ExtResource("2_1i7lb")
-hit_time = 21.32
+hit_time = 21.3249
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_1n61h"]
+[sub_resource type="Resource" id="Resource_u3r28"]
 script = ExtResource("2_1i7lb")
-hit_time = 22.13
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_v7p6k"]
-script = ExtResource("2_1i7lb")
-hit_time = 22.96
+hit_time = 22.9593
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_gsi7a"]
-script = ExtResource("2_1i7lb")
-hit_time = 23.79
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_pqwt7"]
+[sub_resource type="Resource" id="Resource_52efx"]
 script = ExtResource("2_1i7lb")
 hit_time = 24.59
 speed = 0.5
@@ -268,166 +152,742 @@ scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_cnvo0"]
+[sub_resource type="Resource" id="Resource_bc4fd"]
 script = ExtResource("2_1i7lb")
-hit_time = 25.45
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_agkof"]
-script = ExtResource("2_1i7lb")
-hit_time = 25.83
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_msmme"]
-script = ExtResource("2_1i7lb")
-hit_time = 26.21
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_0ojic"]
-script = ExtResource("2_1i7lb")
-hit_time = 27.08
+hit_time = 27.0828
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_1wafx"]
+[sub_resource type="Resource" id="Resource_dt77v"]
 script = ExtResource("2_1i7lb")
-hit_time = 27.47
+hit_time = 27.4667
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_y562r"]
+[sub_resource type="Resource" id="Resource_clud4"]
 script = ExtResource("2_1i7lb")
-hit_time = 27.9
+hit_time = 27.9036
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_h46xg"]
+[sub_resource type="Resource" id="Resource_g7b74"]
 script = ExtResource("2_1i7lb")
-hit_time = 28.7
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_ifjjw"]
-script = ExtResource("2_1i7lb")
-hit_time = 29.14
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_0pxdd"]
-script = ExtResource("2_1i7lb")
-hit_time = 29.54
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_7fji0"]
-script = ExtResource("2_1i7lb")
-hit_time = 30.36
+hit_time = 30.3574
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_5tkt7"]
+[sub_resource type="Resource" id="Resource_q3rs1"]
 script = ExtResource("2_1i7lb")
-hit_time = 31.17
+hit_time = 31.1718
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_165fn"]
+[sub_resource type="Resource" id="Resource_lp2av"]
 script = ExtResource("2_1i7lb")
-hit_time = 32.02
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_runik"]
-script = ExtResource("2_1i7lb")
-hit_time = 32.82
-speed = 0.5
-type = 0
-scene_path = "res://test/test_lane_hit_object.tscn"
-lane_index = 1
-spawn_position = Vector2(0, 0)
-
-[sub_resource type="Resource" id="Resource_cmfab"]
-script = ExtResource("2_1i7lb")
-hit_time = 33.65
+hit_time = 33.651
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_txavk"]
+[sub_resource type="Resource" id="Resource_xltn6"]
 script = ExtResource("2_1i7lb")
-hit_time = 34.45
+hit_time = 34.4547
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 0
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_r5u0n"]
+[sub_resource type="Resource" id="Resource_che0t"]
 script = ExtResource("2_1i7lb")
-hit_time = 35.25
+hit_time = 43.4553
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_2irtw"]
+script = ExtResource("2_1i7lb")
+hit_time = 45.9162
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_j1f8q"]
+script = ExtResource("2_1i7lb")
+hit_time = 47.9892
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_yb7qi"]
+script = ExtResource("2_1i7lb")
+hit_time = 50.0759
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_1cng8"]
+script = ExtResource("2_1i7lb")
+hit_time = 51.6907
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_o65p7"]
+script = ExtResource("2_1i7lb")
+hit_time = 53.3375
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_ftkog"]
+script = ExtResource("2_1i7lb")
+hit_time = 53.7059
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_4w4x6"]
+script = ExtResource("2_1i7lb")
+hit_time = 54.9685
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_fpwfu"]
+script = ExtResource("2_1i7lb")
+hit_time = 55.3536
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_naqoq"]
+script = ExtResource("2_1i7lb")
+hit_time = 56.5729
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_r64je"]
+script = ExtResource("2_1i7lb")
+hit_time = 58.1907
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_kgpwi"]
+script = ExtResource("2_1i7lb")
+hit_time = 59.8171
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_m1v6e"]
+script = ExtResource("2_1i7lb")
+hit_time = 60.2056
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_cdi1u"]
+script = ExtResource("2_1i7lb")
+hit_time = 61.4361
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_l3kb6"]
+script = ExtResource("2_1i7lb")
+hit_time = 61.8207
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_4gs4y"]
+script = ExtResource("2_1i7lb")
+hit_time = 70.772
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_hwvds"]
+script = ExtResource("2_1i7lb")
+hit_time = 71.5902
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_75bc8"]
+script = ExtResource("2_1i7lb")
+hit_time = 71.9769
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_c3hsx"]
+script = ExtResource("2_1i7lb")
+hit_time = 73.2261
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_n4hx7"]
+script = ExtResource("2_1i7lb")
+hit_time = 73.6193
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_xubkt"]
+script = ExtResource("2_1i7lb")
+hit_time = 74.8227
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_jtv1q"]
+script = ExtResource("2_1i7lb")
+hit_time = 75.2217
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_l7oh7"]
+script = ExtResource("2_1i7lb")
+hit_time = 76.4748
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_gjdtt"]
+script = ExtResource("2_1i7lb")
+hit_time = 77.2918
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_123nc"]
+script = ExtResource("2_1i7lb")
+hit_time = 78.0799
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_4jb46"]
+script = ExtResource("2_1i7lb")
+hit_time = 78.492
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_xm54l"]
+script = ExtResource("2_1i7lb")
+hit_time = 79.6921
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_llfkc"]
+script = ExtResource("2_1i7lb")
+hit_time = 80.1118
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_f10h6"]
+script = ExtResource("2_1i7lb")
+hit_time = 81.3212
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_kg0rp"]
+script = ExtResource("2_1i7lb")
+hit_time = 81.714
+speed = 0.5
+type = 1
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 0
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_sbxyc"]
+script = ExtResource("2_1i7lb")
+hit_time = 6.10825
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 1
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_caec1"]
+[sub_resource type="Resource" id="Resource_5vlwu"]
 script = ExtResource("2_1i7lb")
-hit_time = 35.69
+hit_time = 6.93921
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 1
 spawn_position = Vector2(0, 0)
 
-[sub_resource type="Resource" id="Resource_jxa7j"]
+[sub_resource type="Resource" id="Resource_xmsfc"]
 script = ExtResource("2_1i7lb")
-hit_time = 36.12
+hit_time = 12.2481
 speed = 0.5
 type = 0
 scene_path = "res://test/test_lane_hit_object.tscn"
 lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_wmgk7"]
+script = ExtResource("2_1i7lb")
+hit_time = 12.6455
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_7yynn"]
+script = ExtResource("2_1i7lb")
+hit_time = 13.0415
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_dtbto"]
+script = ExtResource("2_1i7lb")
+hit_time = 15.5671
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_pfhan"]
+script = ExtResource("2_1i7lb")
+hit_time = 15.9741
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_slhr7"]
+script = ExtResource("2_1i7lb")
+hit_time = 16.3764
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_lroga"]
+script = ExtResource("2_1i7lb")
+hit_time = 18.8692
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_4q3t4"]
+script = ExtResource("2_1i7lb")
+hit_time = 19.2577
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_bun46"]
+script = ExtResource("2_1i7lb")
+hit_time = 19.6646
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_k6j4w"]
+script = ExtResource("2_1i7lb")
+hit_time = 22.1343
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_7em3f"]
+script = ExtResource("2_1i7lb")
+hit_time = 23.7885
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_xrblv"]
+script = ExtResource("2_1i7lb")
+hit_time = 25.4459
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_gjuqj"]
+script = ExtResource("2_1i7lb")
+hit_time = 25.8341
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_w0jq5"]
+script = ExtResource("2_1i7lb")
+hit_time = 26.2134
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_swdhy"]
+script = ExtResource("2_1i7lb")
+hit_time = 28.7015
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_8kw85"]
+script = ExtResource("2_1i7lb")
+hit_time = 29.1362
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_nwk4c"]
+script = ExtResource("2_1i7lb")
+hit_time = 29.5386
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_unl1u"]
+script = ExtResource("2_1i7lb")
+hit_time = 32.0231
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_3eaur"]
+script = ExtResource("2_1i7lb")
+hit_time = 32.8232
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_52fj6"]
+script = ExtResource("2_1i7lb")
+hit_time = 35.2475
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_0yama"]
+script = ExtResource("2_1i7lb")
+hit_time = 35.6881
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_exfyb"]
+script = ExtResource("2_1i7lb")
+hit_time = 36.1245
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_6ysu8"]
+script = ExtResource("2_1i7lb")
+hit_time = 45.4831
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_e2137"]
+script = ExtResource("2_1i7lb")
+hit_time = 47.6205
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_73yep"]
+script = ExtResource("2_1i7lb")
+hit_time = 50.4902
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_vs1iu"]
+script = ExtResource("2_1i7lb")
+hit_time = 52.0878
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_v6vm6"]
+script = ExtResource("2_1i7lb")
+hit_time = 58.5991
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 1
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_4y8w8"]
+script = ExtResource("2_1i7lb")
+hit_time = 45.0787
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 2
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_klumf"]
+script = ExtResource("2_1i7lb")
+hit_time = 47.1819
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 2
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_ojnmk"]
+script = ExtResource("2_1i7lb")
+hit_time = 50.8825
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 2
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_0gmye"]
+script = ExtResource("2_1i7lb")
+hit_time = 52.5094
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 2
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_jj6t0"]
+script = ExtResource("2_1i7lb")
+hit_time = 58.9919
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 2
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_dcn7a"]
+script = ExtResource("2_1i7lb")
+hit_time = 44.2895
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_24dx1"]
+script = ExtResource("2_1i7lb")
+hit_time = 46.816
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_ux463"]
+script = ExtResource("2_1i7lb")
+hit_time = 48.8362
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_okw1n"]
+script = ExtResource("2_1i7lb")
+hit_time = 49.245
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_hshly"]
+script = ExtResource("2_1i7lb")
+hit_time = 54.1349
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_i57b7"]
+script = ExtResource("2_1i7lb")
+hit_time = 54.5584
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_5af6m"]
+script = ExtResource("2_1i7lb")
+hit_time = 55.7485
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_yy5e7"]
+script = ExtResource("2_1i7lb")
+hit_time = 57.3507
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_22k03"]
+script = ExtResource("2_1i7lb")
+hit_time = 60.608
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_3vckp"]
+script = ExtResource("2_1i7lb")
+hit_time = 61.0155
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
+spawn_position = Vector2(0, 0)
+
+[sub_resource type="Resource" id="Resource_x1p1r"]
+script = ExtResource("2_1i7lb")
+hit_time = 62.218
+speed = 0.5
+type = 0
+scene_path = "res://test/test_lane_hit_object.tscn"
+lane_index = 3
 spawn_position = Vector2(0, 0)
 
 [sub_resource type="Resource" id="Resource_oslxu"]
@@ -465,7 +925,7 @@ height = 648
 fill_to = Vector2(0, 1)
 
 [node name="TestLevel" instance=ExtResource("1_2m27j")]
-_hit_objects_infos = Array[ExtResource("2_1i7lb")]([SubResource("Resource_dubkq"), SubResource("Resource_kh1iu"), SubResource("Resource_iaolx"), SubResource("Resource_3noxh"), SubResource("Resource_mst38"), SubResource("Resource_i6l6g"), SubResource("Resource_lp1k5"), SubResource("Resource_eq8ha"), SubResource("Resource_tauwe"), SubResource("Resource_llk2f"), SubResource("Resource_ia41a"), SubResource("Resource_a3eif"), SubResource("Resource_o8qdm"), SubResource("Resource_0p553"), SubResource("Resource_r7pgp"), SubResource("Resource_x77y4"), SubResource("Resource_ixasb"), SubResource("Resource_k64kr"), SubResource("Resource_81q3p"), SubResource("Resource_or4bv"), SubResource("Resource_7xod2"), SubResource("Resource_3w7ms"), SubResource("Resource_pwlkc"), SubResource("Resource_vx4cd"), SubResource("Resource_cdvkg"), SubResource("Resource_1n61h"), SubResource("Resource_v7p6k"), SubResource("Resource_gsi7a"), SubResource("Resource_pqwt7"), SubResource("Resource_cnvo0"), SubResource("Resource_agkof"), SubResource("Resource_msmme"), SubResource("Resource_0ojic"), SubResource("Resource_1wafx"), SubResource("Resource_y562r"), SubResource("Resource_h46xg"), SubResource("Resource_ifjjw"), SubResource("Resource_0pxdd"), SubResource("Resource_7fji0"), SubResource("Resource_5tkt7"), SubResource("Resource_165fn"), SubResource("Resource_runik"), SubResource("Resource_cmfab"), SubResource("Resource_txavk"), SubResource("Resource_r5u0n"), SubResource("Resource_caec1"), SubResource("Resource_jxa7j")])
+_hit_objects_infos = Array[ExtResource("2_1i7lb")]([SubResource("Resource_mmspf"), SubResource("Resource_2j61d"), SubResource("Resource_s14wv"), SubResource("Resource_vgobn"), SubResource("Resource_jvhl7"), SubResource("Resource_ikqeb"), SubResource("Resource_16sny"), SubResource("Resource_woy21"), SubResource("Resource_6drhp"), SubResource("Resource_uk5wm"), SubResource("Resource_4krew"), SubResource("Resource_agtg6"), SubResource("Resource_0if1l"), SubResource("Resource_ps03s"), SubResource("Resource_u3r28"), SubResource("Resource_52efx"), SubResource("Resource_bc4fd"), SubResource("Resource_dt77v"), SubResource("Resource_clud4"), SubResource("Resource_g7b74"), SubResource("Resource_q3rs1"), SubResource("Resource_lp2av"), SubResource("Resource_xltn6"), SubResource("Resource_che0t"), SubResource("Resource_2irtw"), SubResource("Resource_j1f8q"), SubResource("Resource_yb7qi"), SubResource("Resource_1cng8"), SubResource("Resource_o65p7"), SubResource("Resource_ftkog"), SubResource("Resource_4w4x6"), SubResource("Resource_fpwfu"), SubResource("Resource_naqoq"), SubResource("Resource_r64je"), SubResource("Resource_kgpwi"), SubResource("Resource_m1v6e"), SubResource("Resource_cdi1u"), SubResource("Resource_l3kb6"), SubResource("Resource_4gs4y"), SubResource("Resource_hwvds"), SubResource("Resource_75bc8"), SubResource("Resource_c3hsx"), SubResource("Resource_n4hx7"), SubResource("Resource_xubkt"), SubResource("Resource_jtv1q"), SubResource("Resource_l7oh7"), SubResource("Resource_gjdtt"), SubResource("Resource_123nc"), SubResource("Resource_4jb46"), SubResource("Resource_xm54l"), SubResource("Resource_llfkc"), SubResource("Resource_f10h6"), SubResource("Resource_kg0rp"), SubResource("Resource_sbxyc"), SubResource("Resource_5vlwu"), SubResource("Resource_xmsfc"), SubResource("Resource_wmgk7"), SubResource("Resource_7yynn"), SubResource("Resource_dtbto"), SubResource("Resource_pfhan"), SubResource("Resource_slhr7"), SubResource("Resource_lroga"), SubResource("Resource_4q3t4"), SubResource("Resource_bun46"), SubResource("Resource_k6j4w"), SubResource("Resource_7em3f"), SubResource("Resource_xrblv"), SubResource("Resource_gjuqj"), SubResource("Resource_w0jq5"), SubResource("Resource_swdhy"), SubResource("Resource_8kw85"), SubResource("Resource_nwk4c"), SubResource("Resource_unl1u"), SubResource("Resource_3eaur"), SubResource("Resource_52fj6"), SubResource("Resource_0yama"), SubResource("Resource_exfyb"), SubResource("Resource_6ysu8"), SubResource("Resource_e2137"), SubResource("Resource_73yep"), SubResource("Resource_vs1iu"), SubResource("Resource_v6vm6"), SubResource("Resource_4y8w8"), SubResource("Resource_klumf"), SubResource("Resource_ojnmk"), SubResource("Resource_0gmye"), SubResource("Resource_jj6t0"), SubResource("Resource_dcn7a"), SubResource("Resource_24dx1"), SubResource("Resource_ux463"), SubResource("Resource_okw1n"), SubResource("Resource_hshly"), SubResource("Resource_i57b7"), SubResource("Resource_5af6m"), SubResource("Resource_yy5e7"), SubResource("Resource_22k03"), SubResource("Resource_3vckp"), SubResource("Resource_x1p1r")])
 _transition_infos = Array[ExtResource("3_ppyrm")]([SubResource("Resource_oslxu"), SubResource("Resource_wknyg")])
 
 [node name="Sprite2D" type="Sprite2D" parent="." index="0"]
@@ -483,3 +943,108 @@ stream = ExtResource("3_i8wa8")
 offset_right = 78.0
 offset_bottom = 23.0
 text = "Time: 0.0s"
+
+[node name="AudacityLabelParser" type="Node" parent="." index="8"]
+script = ExtResource("7_iochn")
+label_file_content = "\"lane-0\" 4.441110 4.470110 \"SK\"
+\"lane-0\" 5.278480 5.307480 \"SK\"
+\"lane-0\" 7.758680 7.787690 \"SK\"
+\"lane-0\" 8.578160 8.607170 \"SK\"
+\"lane-0\" 10.620200 10.649200 \"SK\"
+\"lane-0\" 11.428700 11.457700 \"SK\"
+\"lane-0\" 13.908000 13.937000 \"SK\"
+\"lane-0\" 14.325300 14.354300 \"SK\"
+\"lane-0\" 14.742100 14.771100 \"SK\"
+\"lane-0\" 17.195000 17.224000 \"SK\"
+\"lane-0\" 18.004300 18.033300 \"SK\"
+\"lane-0\" 20.506300 20.535400 \"SK\"
+\"lane-0\" 20.899500 20.928500 \"SK\"
+\"lane-0\" 21.324900 21.353900 \"SK\"
+\"lane-0\" 22.959300 22.988300 \"SK\"
+\"lane-0\" 24.590000 24.619000 \"SK\"
+\"lane-0\" 27.082800 27.111800 \"SK\"
+\"lane-0\" 27.466700 27.495700 \"SK\"
+\"lane-0\" 27.903600 27.932600 \"SK\"
+\"lane-0\" 30.357400 30.386400 \"SK\"
+\"lane-0\" 31.171800 31.200800 \"SK\"
+\"lane-0\" 33.651000 33.680000 \"SK\"
+\"lane-0\" 34.454700 34.483700 \"SK\"
+\"lane-0\" 43.455300 43.484300 \"MK\"
+\"lane-0\" 45.916200 45.945200 \"MK\"
+\"lane-0\" 47.989200 48.018200 \"MK\"
+\"lane-0\" 50.075900 50.104900 \"MK\"
+\"lane-0\" 51.690700 51.719700 \"MK\"
+\"lane-0\" 53.337500 53.366500 \"MK\"
+\"lane-0\" 53.705900 53.734900 \"MK\"
+\"lane-0\" 54.968500 54.997600 \"MK\"
+\"lane-0\" 55.353600 55.382600 \"MK\"
+\"lane-0\" 56.572900 56.601900 \"MK\"
+\"lane-0\" 58.190700 58.219700 \"MK\"
+\"lane-0\" 59.817100 59.846100 \"MK\"
+\"lane-0\" 60.205600 60.234600 \"MK\"
+\"lane-0\" 61.436100 61.465100 \"MK\"
+\"lane-0\" 61.820700 61.849700 \"MK\"
+\"lane-0\" 70.772000 70.801000 \"CLK\"
+\"lane-0\" 71.590200 71.619200 \"CLK\"
+\"lane-0\" 71.976900 72.005900 \"CLK\"
+\"lane-0\" 73.226100 73.255100 \"CLK\"
+\"lane-0\" 73.619300 73.648300 \"CLK\"
+\"lane-0\" 74.822700 74.851700 \"CLK\"
+\"lane-0\" 75.221700 75.250700 \"CLK\"
+\"lane-0\" 76.474800 76.503800 \"CLK\"
+\"lane-0\" 77.291800 77.320800 \"CLK\"
+\"lane-0\" 78.079900 78.108900 \"CLK\"
+\"lane-0\" 78.492000 78.521000 \"CLK\"
+\"lane-0\" 79.692100 79.721100 \"CLK\"
+\"lane-0\" 80.111800 80.140800 \"CLK\"
+\"lane-0\" 81.321200 81.350200 \"CLK\"
+\"lane-0\" 81.714000 81.743000 \"CLK\"
+\"lane-1\" 6.108250 6.137260 \"SK\"
+\"lane-1\" 6.939210 6.968210 \"SK\"
+\"lane-1\" 12.248100 12.277100 \"SK\"
+\"lane-1\" 12.645500 12.674500 \"SK\"
+\"lane-1\" 13.041500 13.070500 \"SK\"
+\"lane-1\" 15.567100 15.596100 \"SK\"
+\"lane-1\" 15.974100 16.003100 \"SK\"
+\"lane-1\" 16.376400 16.405400 \"SK\"
+\"lane-1\" 18.869200 18.898200 \"SK\"
+\"lane-1\" 19.257700 19.286700 \"SK\"
+\"lane-1\" 19.664600 19.693600 \"SK\"
+\"lane-1\" 22.134300 22.163300 \"SK\"
+\"lane-1\" 23.788500 23.817500 \"SK\"
+\"lane-1\" 25.445900 25.474900 \"SK\"
+\"lane-1\" 25.834100 25.863100 \"SK\"
+\"lane-1\" 26.213400 26.242400 \"SK\"
+\"lane-1\" 28.701500 28.730500 \"SK\"
+\"lane-1\" 29.136200 29.165200 \"SK\"
+\"lane-1\" 29.538600 29.567600 \"SK\"
+\"lane-1\" 32.023100 32.052100 \"SK\"
+\"lane-1\" 32.823200 32.852200 \"SK\"
+\"lane-1\" 35.247500 35.276500 \"SK\"
+\"lane-1\" 35.688100 35.717100 \"SK\"
+\"lane-1\" 36.124500 36.153500 \"SK\"
+\"lane-1\" 45.483100 45.512100 \"MK\"
+\"lane-1\" 47.620500 47.649500 \"MK\"
+\"lane-1\" 50.490200 50.519300 \"MK\"
+\"lane-1\" 52.087800 52.116800 \"MK\"
+\"lane-1\" 58.599100 58.628100 \"MK\"
+\"lane-2\" 45.078700 45.107700 \"MK\"
+\"lane-2\" 47.181900 47.210900 \"MK\"
+\"lane-2\" 50.882500 50.911500 \"MK\"
+\"lane-2\" 52.509400 52.538400 \"MK\"
+\"lane-2\" 58.991900 59.020900 \"MK\"
+\"lane-3\" 44.289500 44.318500 \"MK\"
+\"lane-3\" 46.816000 46.845000 \"MK\"
+\"lane-3\" 48.836200 48.865200 \"MK\"
+\"lane-3\" 49.245000 49.274000 \"MK\"
+\"lane-3\" 54.134900 54.163900 \"MK\"
+\"lane-3\" 54.558400 54.587400 \"MK\"
+\"lane-3\" 55.748500 55.777500 \"MK\"
+\"lane-3\" 57.350700 57.379700 \"MK\"
+\"lane-3\" 60.608000 60.637000 \"MK\"
+\"lane-3\" 61.015500 61.044500 \"MK\"
+\"lane-3\" 62.218000 62.247000 \"MK\""
+single_key_hit_object_scene_path = "res://test/test_lane_hit_object.tscn"
+multi_key_hit_object_scene_path = "res://test/test_lane_hit_object.tscn"
+click_hit_object_scene_path = "res://test/test_lane_hit_object.tscn"
+result = Array[ExtResource("2_1i7lb")]([SubResource("Resource_mmspf"), SubResource("Resource_2j61d"), SubResource("Resource_s14wv"), SubResource("Resource_vgobn"), SubResource("Resource_jvhl7"), SubResource("Resource_ikqeb"), SubResource("Resource_16sny"), SubResource("Resource_woy21"), SubResource("Resource_6drhp"), SubResource("Resource_uk5wm"), SubResource("Resource_4krew"), SubResource("Resource_agtg6"), SubResource("Resource_0if1l"), SubResource("Resource_ps03s"), SubResource("Resource_u3r28"), SubResource("Resource_52efx"), SubResource("Resource_bc4fd"), SubResource("Resource_dt77v"), SubResource("Resource_clud4"), SubResource("Resource_g7b74"), SubResource("Resource_q3rs1"), SubResource("Resource_lp2av"), SubResource("Resource_xltn6"), SubResource("Resource_che0t"), SubResource("Resource_2irtw"), SubResource("Resource_j1f8q"), SubResource("Resource_yb7qi"), SubResource("Resource_1cng8"), SubResource("Resource_o65p7"), SubResource("Resource_ftkog"), SubResource("Resource_4w4x6"), SubResource("Resource_fpwfu"), SubResource("Resource_naqoq"), SubResource("Resource_r64je"), SubResource("Resource_kgpwi"), SubResource("Resource_m1v6e"), SubResource("Resource_cdi1u"), SubResource("Resource_l3kb6"), SubResource("Resource_4gs4y"), SubResource("Resource_hwvds"), SubResource("Resource_75bc8"), SubResource("Resource_c3hsx"), SubResource("Resource_n4hx7"), SubResource("Resource_xubkt"), SubResource("Resource_jtv1q"), SubResource("Resource_l7oh7"), SubResource("Resource_gjdtt"), SubResource("Resource_123nc"), SubResource("Resource_4jb46"), SubResource("Resource_xm54l"), SubResource("Resource_llfkc"), SubResource("Resource_f10h6"), SubResource("Resource_kg0rp"), SubResource("Resource_sbxyc"), SubResource("Resource_5vlwu"), SubResource("Resource_xmsfc"), SubResource("Resource_wmgk7"), SubResource("Resource_7yynn"), SubResource("Resource_dtbto"), SubResource("Resource_pfhan"), SubResource("Resource_slhr7"), SubResource("Resource_lroga"), SubResource("Resource_4q3t4"), SubResource("Resource_bun46"), SubResource("Resource_k6j4w"), SubResource("Resource_7em3f"), SubResource("Resource_xrblv"), SubResource("Resource_gjuqj"), SubResource("Resource_w0jq5"), SubResource("Resource_swdhy"), SubResource("Resource_8kw85"), SubResource("Resource_nwk4c"), SubResource("Resource_unl1u"), SubResource("Resource_3eaur"), SubResource("Resource_52fj6"), SubResource("Resource_0yama"), SubResource("Resource_exfyb"), SubResource("Resource_6ysu8"), SubResource("Resource_e2137"), SubResource("Resource_73yep"), SubResource("Resource_vs1iu"), SubResource("Resource_v6vm6"), SubResource("Resource_4y8w8"), SubResource("Resource_klumf"), SubResource("Resource_ojnmk"), SubResource("Resource_0gmye"), SubResource("Resource_jj6t0"), SubResource("Resource_dcn7a"), SubResource("Resource_24dx1"), SubResource("Resource_ux463"), SubResource("Resource_okw1n"), SubResource("Resource_hshly"), SubResource("Resource_i57b7"), SubResource("Resource_5af6m"), SubResource("Resource_yy5e7"), SubResource("Resource_22k03"), SubResource("Resource_3vckp"), SubResource("Resource_x1p1r")])


### PR DESCRIPTION
# Relevant changes:
- Implemented AudacityLabelParser class to parse content from label files from Audacity
  - Files must have each HitObject in a line;
  - Line parameters must be:
    1. `"lane-<number>"`: Include the quotes and replace the value `<number>` by the lane index (Ex: `"line-0"`);
    2. `start_time`: Start time (in seconds) of the HitObject;
    3. `end_time`: This parametes is ignored during processing;
    4. `"MODE"`: This is the target mode for the HitObject. Value must be "SK" (for single-key), "MK" (for multi-key) or "CLK" (for click), with quotes included;
  - Full line example: `"lane-2" 47.181900 47.210900 "MK"`.